### PR TITLE
[Improve] RecentSubmission: thêm phân trang và cho phép đổi id cùng loại tài nguyên

### DIFF
--- a/src/components/Content/Content.jsx
+++ b/src/components/Content/Content.jsx
@@ -50,7 +50,7 @@ class Content extends React.Component {
                         <h4 className="">Bách Khoa Đà Nẵng Online Judge 2.0</h4>
                         <div className="title">
                           <h5 className="">ver. <span className="code-markup">preALPHA</span></h5>
-                          <span className="code-markup">22年07月27日</span>
+                          <span className="code-markup">22年07月30日</span>
                         </div>
                       </div>
                       <span className="subtext text-center">Your new online platform for practicing and hosting programming contests, for Vietnam Central Province.</span>

--- a/src/components/ErrorBox/ErrorBox.scss
+++ b/src/components/ErrorBox/ErrorBox.scss
@@ -16,7 +16,7 @@
     * {
         margin: 0;
         font-size: 12px;
-        color: $red-light
+        color: $red-light;
     }
     font-family: $font-subscript;
 

--- a/src/pages/user/UserApp.scss
+++ b/src/pages/user/UserApp.scss
@@ -11,6 +11,8 @@
   padding-top: 30px;
   padding-bottom: 30px;
 
+  min-height: 60vh;
+
 	background: linear-gradient(to bottom,
     $background-gray 0%, $background-gray 10%,
     $sub 60%, $sub 100%

--- a/src/pages/user/problem/ProblemDetails.jsx
+++ b/src/pages/user/problem/ProblemDetails.jsx
@@ -120,6 +120,13 @@ class ProblemDetails extends React.Component {
     } else this.callApi({page: this.state.currPage})
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.shortname !== this.props.params.shortname) {
+      this.shortname = this.props.params.shortname
+      this.callApi()
+    }
+  }
+
   parseMemoryLimit() {
     return `${(this.state.data.memory_limit)} KB(s)`
   }
@@ -237,14 +244,19 @@ class ProblemDetails extends React.Component {
                 {
                   // TODO: cached this after first load so it doesn't hit the server everytime the user toggle doc type.
                   this.state.probStatementType === 'pdf' &&
-                  <div className="problem-pdf shadow">
-                    {/* <object data={`${data.pdf}`} type="application/pdf">
-                      <iframe title="problem-pdf-iframe"
-                        src={`https://docs.google.com/viewer?url=${this.state.data.pdf}&embedded=true`}>
-                      </iframe>
-                    </object> */}
-                    <PDFViewer pdf={`${data.pdf}${pdfExtraQuery}`} />
-                  </div>
+                  <>
+                    <span className="w-100 text-right text-danger">
+                      <em>**Đôi khi PDF mãi loading, hãy nhấn biểu tượng Kính lúp (resize) để refresh.</em>
+                    </span>
+                    <div className="problem-pdf shadow">
+                      {/* <object data={`${data.pdf}`} type="application/pdf">
+                        <iframe title="problem-pdf-iframe"
+                          src={`https://docs.google.com/viewer?url=${this.state.data.pdf}&embedded=true`}>
+                        </iframe>
+                      </object> */}
+                      <PDFViewer pdf={`${data.pdf}${pdfExtraQuery}`} />
+                    </div>
+                  </>
                 }{
                   this.state.probStatementType === 'text' &&
                   (

--- a/src/pages/user/submission/SubmissionDetails.jsx
+++ b/src/pages/user/submission/SubmissionDetails.jsx
@@ -133,6 +133,12 @@ class SubmissionDetails extends React.Component {
       setTimeout(() => clearInterval(this.timer), __SUBMISSION_MAX_POLL_DURATION);
     }
   }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.params.id !== this.state.id) {
+      this.setState({ loaded: false, errors: false })
+      this.setState({ id: this.props.params.id }, ()=>this.fetch())
+    }
+  }
 
   componentWillUnmount() {
     clearInterval(this.timer)


### PR DESCRIPTION
* Phân trang:
![image](https://user-images.githubusercontent.com/24392632/181909551-a06c8cba-c1e9-4712-bc1a-964af6d1b9cc.png)
* Vì React Router sẽ không load lại component nếu link được nhấn vẫn trỏ đến cùng component, một cách là ta sẽ sử dụng life-cycle `componentDidUpdate()` để bắt sự kiện `id` trên thanh URL thay đổi, từ đó tự invoke hàm fetch và ép reload.
https://github.com/BKDN-University/bkdnOJ-reborn-frontend/blob/4b2ea530beb7045cef40b4eb6c2284472f5d4c52/src/pages/user/problem/ProblemDetails.jsx#L123-L128