### PR TITLE
Improved Organization UI: Org browser view and detail view

### DIFF
--- a/src/api/organization/index.js
+++ b/src/api/organization/index.js
@@ -1,7 +1,10 @@
 import axiosClient from "api/axiosClient";
 
-const getOrgs = ({params}) => {
-    return axiosClient.get('/orgs/', (params && { params: {...params} }));
+const getOrgs = ({slug, params}) => {
+    if (slug)
+        return axiosClient.get(`/org/${slug}/orgs`, (params && { params: {...params} }));
+    else
+        return axiosClient.get('/orgs/', (params && { params: {...params} }));
 }
 
 const getMyOrgs = () => {

--- a/src/api/organization/index.js
+++ b/src/api/organization/index.js
@@ -11,6 +11,16 @@ const getMyOrgs = () => {
     return axiosClient.get('/orgs/my/', );
 }
 
+
+const joinOrg = ({ slug, data }) => {
+    return axiosClient.post(`/org/${slug}/membership/`, data)
+}
+
+const leaveOrg = ({ slug }) => {
+    return axiosClient.delete(`/org/${slug}/membership/`)
+}
+
+
 const createOrg = ( data ) => {
     return axiosClient.post(`/orgs/`, data );
 }
@@ -47,6 +57,8 @@ const orgAPI = {
     createOrg,
     getOrg, updateOrg, deleteOrg,
     createSubOrg,
+
+    joinOrg, leaveOrg,
 
     getOrgMembers,
     addOrgMembers,

--- a/src/pages/admin/org/Details.jsx
+++ b/src/pages/admin/org/Details.jsx
@@ -153,15 +153,15 @@ class OrgDetail extends React.Component {
                         </Row>
 
                         <Row>
-                          <Form.Label column="sm" md={2} > Không hiển thị lên web? </Form.Label>
-                          <Col md={4}> <Form.Control size="sm" type="checkbox" id="is_unlisted" checked={data.is_unlisted || false}
+                          <Form.Label column="sm" md={3} > Không hiển thị lên web? </Form.Label>
+                          <Col md={3}> <Form.Control size="sm" type="checkbox" id="is_unlisted" checked={data.is_unlisted || false}
                                     onChange={(e) => this.inputChangeHandler(e, {isCheckbox: true})} />
                           </Col>
 
-                          {/* <Form.Label column="sm" md={2} > Ai cũng join được? </Form.Label>
-                          <Col > <Form.Control size="sm" type="checkbox" id="is_open" checked={data.is_open || false}
+                          <Form.Label column="sm" md={3} > Ai cũng join được? </Form.Label>
+                          <Col md={3}> <Form.Control size="sm" type="checkbox" id="is_open" checked={data.is_open || false}
                                     onChange={(e) => this.inputChangeHandler(e, {isCheckbox: true})} />
-                          </Col> */}
+                          </Col>
                         </Row>
 
                         <Row>
@@ -215,6 +215,40 @@ class OrgDetail extends React.Component {
                           </Col>
                         </Row>
 
+                        <strong>Mã truy cập tổ chức</strong>
+                        <Row>
+                          <Form.Label column="sm" md={4}> Protected? </Form.Label>
+                          <Col md={8}>
+                            <Form.Control size="sm" type="checkbox" id="is_protected" checked={data.is_protected || false}
+                                          onChange={(e) => this.inputChangeHandler(e, {isCheckbox: true})} />
+                          </Col>
+                          <Col xl={12}>
+                            <sub>Cần mã truy cập để tham gia vào tổ chức?</sub>
+                          </Col>
+
+                          <Form.Label column="sm" xl={12} > Access Code Prompt </Form.Label>
+                          <Col xl={12}>
+                            <Form.Control as="textarea" id="access_code_prompt"
+                              value={data.access_code_prompt || ''} onChange={(e)=>this.inputChangeHandler(e)}
+                            />
+                          </Col>
+                          <Col xl={12}>
+                            <sub>Thông điệp hiển thị ở màn hình hỏi mã truy cập tổ chức.</sub>
+                          </Col>
+
+                          <Form.Label column="sm" xl={12}> Access Code </Form.Label>
+                          <Col xl={12}>
+                            <Form.Control size="sm" type="text" id="access_code"
+                                  value={data.access_code || ''}
+                                  onChange={(e)=>this.inputChangeHandler(e)}/>
+                          </Col>
+                          <Col xl={12}>
+                            <sub>Mã truy cập vào tổ chức.</sub>
+                          </Col>
+                        </Row>
+
+
+                      <strong>Khác</strong>
                       <Row>
                         <Form.Label column="sm" xs={6}> Total Member count: </Form.Label>
                         <Col xs={6}>

--- a/src/pages/admin/org/List.scss
+++ b/src/pages/admin/org/List.scss
@@ -1,2 +1,97 @@
 @import 'global.scss';
 
+div#org-main {
+    div#org-title-div {
+        min-height: 40px;
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+        margin: 3px 0;
+
+        row-gap: 5px;
+
+        div.org-path {
+            display: flex;
+            flex-direction: row;
+            justify-content: flex-start;
+            column-gap: 10px;
+            align-items: center;
+
+            div.org-path-item {
+                display: flex;
+                flex-direction: row;
+                justify-content: center;
+                align-items: center;
+
+                // max-width: 180px;
+
+                border: solid 2px rgba(0, 0, 0, .1);
+                padding: 2px 5px;
+                border-radius: 5px;
+
+                img.org-path-item-img {
+                    // height: 30px;
+                    width: auto;
+                    margin-right: 10px;
+                }
+                span.org-path-item-slug {
+                    font-family: $font-brand;
+                    font-weight: bold;
+                }
+            }
+        }
+    }
+
+    div.org-table {
+        div.org-name-wrapper {
+            // margin-left: 10px;
+            text-align: left;
+
+            h6 {
+                font-family: $font-brand;
+                font-weight: bold;
+                margin: 0;
+            }
+        }
+    }
+
+    div.org-detail-wrapper-col {
+        div.org-detail-wrapper {
+            height: 100%;
+            display: flex;
+            align-self: baseline;
+            flex-direction: column;
+
+            // row-gap: 10px;
+
+            margin-right: 4px;
+            padding-right: 4px;
+            overflow-y: auto;
+
+            h5.org-detail-title {
+                font-family: $font-brand;
+                font-weight: bold;
+                font-size: x-large;
+            }
+
+            div.org-detail-item {
+                word-break: break-word;
+                margin: 6px;
+                padding: 4px;
+                text-align: left;
+
+                &:first-child { margin-top: 0; }
+                &:last-child { margin-bottom: 0; }
+            }
+        }
+    }
+
+    div.org-table-wrapper-col {
+        div.org-table-wrapper {
+            max-height: 60vh;
+            display: block;
+            overflow: auto;
+        }
+    }
+}

--- a/src/pages/user/UserApp.scss
+++ b/src/pages/user/UserApp.scss
@@ -4,14 +4,14 @@
   // display: flex;
   // justify-content: center;
   // align-items: center;
-  display: block;
+  display: grid;
 
   // border: solid 2px $base;
   // border-radius: 3px;
   padding-top: 30px;
   padding-bottom: 30px;
 
-  min-height: 60vh;
+  min-height: 55vh;
 
 	background: linear-gradient(to bottom,
     $background-gray 0%, $background-gray 10%,

--- a/src/pages/user/UserApp.scss
+++ b/src/pages/user/UserApp.scss
@@ -1,10 +1,9 @@
 @import 'global.scss';
 
 .content-wrapper {
-  // display: flex;
-  // justify-content: center;
-  // align-items: center;
-  display: grid;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   // border: solid 2px $base;
   // border-radius: 3px;

--- a/src/pages/user/organization/List.jsx
+++ b/src/pages/user/organization/List.jsx
@@ -268,8 +268,12 @@ class OrgDetail extends React.Component {
               <div style={{ position: "absolute", right: 5, top: 5, width: "30px", }}>
                 <Button   className="btn-svg" variant="secondary" size="sm" 
                           onClick={()=>this.props.deselectOrg()}> <FaTimes/> </Button>
-                <Button   className="btn-svg" variant="danger" size="sm" 
-                          onClick={()=>this.setState({ redirectUrl: `/admin/org/${slug}/` })}> <FaWrench/> </Button>
+                {
+                  isStaff && (
+                    <Button className="btn-svg" variant="danger" size="sm" 
+                            onClick={()=>this.setState({ redirectUrl: `/admin/org/${slug}/` })}> <FaWrench/> </Button>
+                  )
+                }
               </div>
       {
         !loaded && <div className="flex-center-col"><SpinLoader margin="0" size={50}/></div>

--- a/src/pages/user/organization/List.jsx
+++ b/src/pages/user/organization/List.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import ReactPaginate from 'react-paginate';
-import { Link } from 'react-router-dom';
-import { Table } from 'react-bootstrap';
+import { Link, Navigate } from 'react-router-dom';
+import { Table, Row, Col, Button } from 'react-bootstrap';
 // import { FaPaperPlane } from 'react-icons/fa';
 
-import { SpinLoader, ErrorBox } from 'components';
+import { SpinLoader, ErrorBox, } from 'components';
 import orgAPI from 'api/organization';
 import dateFormatter, {getYearMonthDate, getHourMinuteSecond} from 'helpers/dateFormatter';
 
+// Helpers
 import { setTitle } from 'helpers/setTitle';
 import { parseTime, parseMem } from 'helpers/textFormatter';
+import { withParams } from 'helpers/react-router'
 
 // Contexts
 import ContestContext from 'context/ContestContext';
@@ -19,18 +21,19 @@ import { toast } from 'react-toastify';
 // Styles
 import 'styles/ClassicPagination.scss';
 import './List.scss';
-import { FaUniversity } from 'react-icons/fa';
+import { FaUniversity, FaGreaterThan, FaGlobe, FaLock, FaTimes, FaPlus, FaSignInAlt } from 'react-icons/fa';
 
 class OrgItem extends React.Component {
   constructor(props) {
     super(props);
   }
+
   render() {
-    const { slug, name, logo_url, suborg_count, member_count } = this.props.org;
+    const { slug, name, logo_url, suborg_count, member_count, about } = this.props.org;
 
     return (
-      <tr key={`org-${slug}`}>
-        <td className="org-i">
+      <tr key={`org-${slug}`} className="org-list org-item">
+        <td className="org-i" style={{height: "100px"}}>
           <div className="org-img-wrapper">
             {
               logo_url ? <img id="org-img" src={logo_url}/>
@@ -39,9 +42,28 @@ class OrgItem extends React.Component {
           </div>
           <span className="org-slug">{slug}</span>
         </td>
-        <td className="org-name">{name}</td>
-        <td className="suborg_count">{suborg_count}</td>
-        <td className="member_count">{member_count}</td>
+
+        <td className="org-name-td" >
+          <div className="d-block ">
+            <div className="org-name-wrapper border-bottom m-2" >
+              <h6 className="org-name">{name}</h6>
+            </div>
+
+            <div className="org-about-wrapper text-truncate">
+              { about ? "" : <em>No description.</em> }
+            </div>
+
+            <div className="org-panel text-right">
+              <Link to="#" className="ml-2 mr-2"
+                    onClick={() => this.props.pushToPath(this.props.org)}>Browse</Link>
+              |
+              <Link to="#" className="ml-2 mr-2"
+                    onClick={this.props.onClick}>Detail</Link>
+            </div>
+          </div>
+        </td>
+        {/* <td className="suborg_count">{suborg_count}</td>
+        <td className="member_count">{member_count}</td> */}
       </tr>
     )
   }
@@ -58,11 +80,17 @@ class OrgList extends React.Component {
       count: 0,
       currPage: 0,
       pageCount: 1,
+
+      path: [],
     }
   }
 
   refetch(params={page: 0}) {
+    this.setState({ loaded: false, errors: null, })
+    const slug = (this.state.path.length === 0 ? null : this.state.path[this.state.path.length - 1].slug)
+
     orgAPI.getOrgs({
+      slug: slug,
       params: {page: params.page+1}
     })
     .then((res) => {
@@ -80,9 +108,18 @@ class OrgList extends React.Component {
   }
 
   componentDidMount() {
-    setTitle("Organizations");
     this.refetch();
   }
+  
+  componentDidUpdate(prevProps, prevState){
+    if (this.props.path !== this.state.path) {
+      this.setState({ path: this.props.path }, () => {
+        console.log(this.state.path)
+        this.refetch()
+      })
+    }
+  }
+
   handlePageClick = (event) => {
     this.refetch({page: event.selected});
   }
@@ -91,32 +128,32 @@ class OrgList extends React.Component {
     const { loaded, errors, orgs, count } = this.state;
 
     return (
-      <div className="org-table wrapper-vanilla">
-        <h4>Organizations</h4>
-        <ErrorBox errors={errors} />
-        <Table responsive hover size="sm" striped bordered className="rounded">
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>Tên tổ chức</th>
-              <th>Số tổ chức con</th>
-              <th>Số thành viên</th>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              !loaded
-                ? <tr><td colSpan="99"><SpinLoader margin="10px" /></td></tr>
-                : (
-                  !errors && <> {
-                    count > 0
-                      ? orgs.map((org, ridx) => <OrgItem org={org} ridx={ridx} key={`org${org.slug}`}/>)
-                      : <tr><td colSpan={99}><em>No orgs are available yet.</em></td></tr>
-                    }</>
-                )
-            }
-          </tbody>
-        </Table>
+      <div className="org-table">
+        {/* <h4>Organizations</h4> */}
+        <div className="org-table-wrapper ml-1 mr-1 border-bottom">
+          <Table responsive hover size="sm" striped bordered className="rounded">
+            <tbody className="w-100">
+              {
+                !loaded
+                  ? <tr style={{ height: "400px" }}><td colSpan="99"><SpinLoader margin="10px" /></td></tr>
+                  : (
+                    !errors && <> {
+                      count > 0
+                        ? orgs.map((org, ridx) => <OrgItem 
+                            {...this.props}
+                            org={org} ridx={ridx} key={`org${org.slug}`}
+                            onClick={() => {
+                              if (this.props.selectedOrg === org.slug) this.props.deselectOrg();
+                              else this.props.selectOrg(org.slug);
+                            }}
+                        />)
+                        : <tr style={{ height: "400px" }}><td colSpan={99}><em>No orgs are available yet.</em></td></tr>
+                      }</>
+                  )
+              }
+            </tbody>
+          </Table>
+        </div>
         {
           this.state.loaded === false
             ? <SpinLoader margin="0" />
@@ -137,4 +174,221 @@ class OrgList extends React.Component {
   }
 }
 
-export default OrgList;
+class OrgDetail extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      slug: this.props.slug,
+
+      loaded: false,
+      errors: null,
+      org: null,
+    }
+  }
+
+  fetch() {
+    this.setState({ loaded: false, errors: null, })
+      orgAPI.getOrg({ slug: this.state.slug })
+      .then((res) => {
+        this.setState({ loaded: true, org: res.data })
+      })
+      .catch((err) => {
+        this.setState({ loaded: true, errors: err.response.data })
+      })
+  }
+
+  componentDidMount() {
+    this.fetch()
+  }
+  componentDidUpdate() {
+    if (this.state.slug !== this.props.slug) {
+      this.setState({slug : this.props.slug}, () => this.fetch() )
+    }
+  }
+
+  render() {
+    if (this.state.redirectUrl) return <Navigate to={`${this.state.redirectUrl}`} />
+
+    const {slug, loaded, errors, org} = this.state;
+    const { user } = this.props;
+
+    const isLoggedIn = (user !== null);
+
+    return <div className="org-detail-wrapper border" style={{ position: "relative" }}>
+              <Button   className="btn-svg" style={{ position: "absolute", right: 5, top: 5, width: "30px", }}
+                        variant="danger" size="sm" onClick={()=>this.props.deselectOrg()}> <FaTimes/> </Button>
+      {
+        !loaded && <div className="flex-center-col"><SpinLoader margin="0" size={50}/></div>
+      }{
+        loaded && <>
+          <span className="d-flex justify-content-center align-items-center">
+            {
+              org.logo_url 
+              ? <img className="org-path-item-img" src={org.logo_url} alt={`${org.slug} logo`} height={ORG_PATH_IMG_SIZE}/> 
+              : <FaUniversity size={ORG_PATH_IMG_SIZE}/>
+            }
+            <h5 className="m-0 p-2 org-detail-title">{org.short_name}</h5>
+          </span>
+          
+          { isLoggedIn && <span><code>You are {!org.is_member && "not"} a member of this organization.</code></span> }
+
+          <div className="org-detail-item border" >
+            <h6 className="m-0"> <code>{org.slug}</code> | {org.short_name}</h6>
+            <h6 className="mb-1">{org.name}</h6>
+            <span className="float-right" style={{fontSize: "12px"}}>
+              <em>Created {new Date(org.creation_date).toLocaleString()}</em>
+            </span>
+          </div>
+
+          <div className="org-detail-item border" >
+            <h6 className="m-0">About</h6>
+            {org.about}
+          </div>
+
+          <div className="org-detail-item border d-flex justify-content-around" >
+            <div > {org.suborg_count} org(s) </div>
+            <div > {org.member_count} member(s) </div>
+            {/* <div > {org.real_member_count} member(s) </div> */}
+          </div>
+
+          <div className="org-detail-item border" >
+            <h6 className="m-0">Organization Admins</h6>
+            {
+              org.admins.length === 0 ? <div style={{height: "50px"}} className="flex-center">
+                <em>Currently there is no one.</em>
+              </div> : <ul className="m-0">
+                { org.admins.map((user) => <li key={`org-detail-admin-${user.username}`}>
+                  User <code>{user.username}</code>
+                  <ul>
+                    <li><strong>Name</strong>: {user.first_name} {user.last_name}</li>
+                    <li><strong>Email</strong>: <code>{user.email}</code></li>
+                  </ul>
+                </li>)} 
+              </ul>
+            }
+          </div>
+
+            <div className="org-detail-item border d-flex justify-content-around">
+              { isLoggedIn ? 
+                  org.is_member ? 
+                    <Button size="sm" className="btn-svg" variant="danger">
+                      Leave <FaTimes/>
+                    </Button> 
+                  : (
+                    org.is_open ? <Button size="sm" className="btn-svg" variant={org.is_protected ? "warning" : "primary"}>
+                      Join {org.is_protected ? <FaLock/> : <FaPlus/>}
+                    </Button>
+                    : <strong>This organization is private.</strong>
+                  )
+                : <Button className="btn-svg" size="sm" variant="secondary"
+                    onClick={() => this.setState({redirectUrl: '/sign-in'})}>
+                      Sign In to Join <FaSignInAlt size={12}/>
+                  </Button>
+              }
+            </div>
+        </>
+      } 
+    </div>
+  }
+}
+
+const ORG_PATH_IMG_SIZE = 25;
+
+class OrgMain extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedOrg: null,
+      path: [],
+      errors: null,
+    }
+  }
+
+  selectOrg(slug) {
+    this.setState({ selectedOrg: slug })
+  }
+  deselectOrg() {
+    this.setState({ selectedOrg: null })
+  }
+  
+  componentDidMount() {
+    setTitle("Organizations");
+  }
+
+  render() {
+    const { path, selectedOrg, errors } = this.state
+
+    return (
+      <div className="wrapper-vanilla" id="org-main">
+        <Row id="org-title-div">
+          <Col md={3} className="flex-center-col">
+            <h4 className="pl-2 pr-2 m-0">Organization</h4>
+          </Col>
+          <Col className="org-path" style={{width: "100%", heigth: "100%", overflow: "hidden"}}>
+            <div style={{width: "100%", heigth: "100%", overflowX: "auto", boxSizing: "content-box"}} className="d-flex">
+
+              <div className="org-path-item"> 
+                <Link to="#" onClick={() => this.setState({ path: [] })} className="text-dark">
+                  <FaGlobe size={ORG_PATH_IMG_SIZE}/>
+                </Link>
+              </div>
+
+              {
+                path.map((org, idx) => {
+                  return <>
+                    <div className="org-path-divider">
+                      <div className="flex-center-col">
+                        <FaGreaterThan/>
+                      </div>
+                    </div>
+                    <div className="org-path-item"> 
+                      <Link className="d-inline-flex" to="#" onClick={() => this.setState({ path: path.slice(0, idx+1) }) } >
+                        { 
+                          org.logo_url ? 
+                          <img className="org-path-item-img" src={org.logo_url} alt={`${org.slug} logo`} height={ORG_PATH_IMG_SIZE}/> 
+                          : <FaUniversity size={ORG_PATH_IMG_SIZE}/>
+                        }
+                        <div className="org-path-item-slug text-truncate"> {org.slug} </div>
+                      </Link>
+                    </div>
+                  </>
+                })
+              }
+
+            </div>
+          </Col>
+        </Row>
+
+        {
+          errors && <div className="error-box-wrapper m-2">
+            <ErrorBox errors={errors} />
+          </div>
+        }
+
+        <Row>
+          <Col className="org-table-wrapper-col ml-1 mr-1" >
+            <OrgList  selectedOrg={selectedOrg} selectOrg={(slug) => this.selectOrg(slug)} deselectOrg={() => this.deselectOrg()} 
+                      path={path} pushToPath={(newOrg) => {
+                        this.setState({ path: path.concat(newOrg) }) 
+                      }} />
+          </Col>
+          {
+            selectedOrg && 
+            <Col className="org-detail-wrapper-col mr-1 mb-1" md={6}>
+              <OrgDetail {...this.props} slug={selectedOrg} deselectOrg={() => this.deselectOrg()} />
+            </Col>
+          }
+        </Row>
+      </div>
+    )
+  }
+}
+
+let wrappedPD = OrgMain;
+wrappedPD = withParams(wrappedPD);
+const mapStateToProps = state => {
+  return { user : state.user.user }
+}
+wrappedPD = connect(mapStateToProps, null)(wrappedPD);
+export default wrappedPD;
+


### PR DESCRIPTION
* List Orgs: ![image](https://user-images.githubusercontent.com/24392632/182444471-9f9b5e57-516f-40d1-9599-5d65cc91c1d3.png)
* Orgs Listing with Detail view: ![image](https://user-images.githubusercontent.com/24392632/182444602-4bf91604-8099-410b-b35b-5b4bdc4e0300.png)
* Clicking `Browse` will add that Org to the Path, and Willl update the organization list to sub organizations of the clicked org.
* Clicking `Detail` will open/close the Detail view.
* You can return to previous organization by clicking Orgs on top of the interface 
![image](https://user-images.githubusercontent.com/24392632/182444802-28554190-e567-4957-a705-17da96b7f8f9.png)

